### PR TITLE
Refactor MapPoint animations and styling for planets

### DIFF
--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -248,43 +248,43 @@ export const MapPoint: React.FC<MapPointProps> = ({
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F7e4bf7fbfae64dec9a1f6cc4cf45cae2?format=webp&width=800"
             alt="Mundo Gelado"
-            className="w-full h-full object-cover rounded-full"
+            className="w-60 h-60 object-contain"
           />
         ) : point.id === "planeta-limite" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F32e8fdb02b8847e2905c284b102c06f1?format=webp&width=800"
             alt="Planeta Limite"
-            className="w-full h-full object-cover rounded-full"
+            className="w-60 h-60 object-contain"
           />
         ) : point.id === "estacao-borda" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fddc08062fa4847258d35e5b4220283d2?format=webp&width=800"
             alt="Estação da Borda"
-            className="w-full h-full object-cover rounded-full"
+            className="w-60 h-60 object-contain"
           />
         ) : point.id === "campo-asteroides" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fd72456f351f44914a7041ea650599fa5?format=webp&width=800"
             alt="Campo de Asteroides"
-            className="w-full h-full object-cover rounded-full"
+            className="w-60 h-60 object-contain"
           />
         ) : point.id === "nebulosa-crimson" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F69aee9aae2844db097785996005e39f4?format=webp&width=800"
             alt="Nebulosa Crimson"
-            className="w-full h-full object-cover rounded-full"
+            className="w-60 h-60 object-contain"
           />
         ) : point.id === "estacao-omega" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F33bc3a2c9ab640e8a3a4e31a127b186c?format=webp&width=800"
             alt="Estação Omega"
-            className="w-full h-full object-cover rounded-full"
+            className="w-60 h-60 object-contain"
           />
         ) : point.id === "terra-nova" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F50c9b6d67a104a3493aa90dd1b8ec545?format=webp&width=800"
             alt="Terra Nova"
-            className="w-full h-full object-cover rounded-full"
+            className="w-60 h-60 object-contain"
           />
         ) : (
           <Icon size={14} className="text-white drop-shadow-sm" />

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -249,6 +249,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F7e4bf7fbfae64dec9a1f6cc4cf45cae2?format=webp&width=800"
             alt="Mundo Gelado"
             className="w-32 h-32 object-cover"
+            style={{
+              filter: "drop-shadow(0 0 1px rgba(255, 255, 255, 0.2))",
+            }}
             animate={{
               y: [0, -8, 0],
               x: [0, 3, 0],
@@ -266,6 +269,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F32e8fdb02b8847e2905c284b102c06f1?format=webp&width=800"
             alt="Planeta Limite"
             className="w-32 h-32 object-cover"
+            style={{
+              filter: "drop-shadow(0 0 1px rgba(255, 255, 255, 0.2))",
+            }}
             animate={{
               y: [0, -5, 0],
               x: [0, -4, 0],
@@ -283,6 +289,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fddc08062fa4847258d35e5b4220283d2?format=webp&width=800"
             alt="Estação da Borda"
             className="w-32 h-32 object-cover"
+            style={{
+              filter: "drop-shadow(0 0 1px rgba(255, 255, 255, 0.2))",
+            }}
             animate={{
               y: [0, -6, 0],
               x: [0, 2, 0],
@@ -300,6 +309,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fd72456f351f44914a7041ea650599fa5?format=webp&width=800"
             alt="Campo de Asteroides"
             className="w-32 h-32 object-cover"
+            style={{
+              filter: "drop-shadow(0 0 1px rgba(255, 255, 255, 0.2))",
+            }}
             animate={{
               y: [0, -7, 0],
               x: [0, -3, 0],
@@ -317,6 +329,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F69aee9aae2844db097785996005e39f4?format=webp&width=800"
             alt="Nebulosa Crimson"
             className="w-32 h-32 object-cover"
+            style={{
+              filter: "drop-shadow(0 0 1px rgba(255, 255, 255, 0.2))",
+            }}
             animate={{
               y: [0, -9, 0],
               x: [0, 4, 0],
@@ -334,6 +349,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F33bc3a2c9ab640e8a3a4e31a127b186c?format=webp&width=800"
             alt="Estação Omega"
             className="w-32 h-32 object-cover"
+            style={{
+              filter: "drop-shadow(0 0 1px rgba(255, 255, 255, 0.2))",
+            }}
             animate={{
               y: [0, -4, 0],
               x: [0, -2, 0],
@@ -351,6 +369,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F50c9b6d67a104a3493aa90dd1b8ec545?format=webp&width=800"
             alt="Terra Nova"
             className="w-32 h-32 object-cover"
+            style={{
+              filter: "drop-shadow(0 0 1px rgba(255, 255, 255, 0.2))",
+            }}
             animate={{
               y: [0, -6, 0],
               x: [0, 3, 0],

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -215,7 +215,7 @@ export const MapPoint: React.FC<MapPointProps> = ({
           point.id === "nebulosa-crimson" ||
           point.id === "estacao-omega" ||
           point.id === "terra-nova"
-            ? "w-60 h-60"
+            ? "w-60 h-60 rounded-full"
             : "w-6 h-6 rounded-full"
         }`}
         style={{
@@ -229,7 +229,10 @@ export const MapPoint: React.FC<MapPointProps> = ({
             point.id === "terra-nova"
               ? "transparent"
               : `linear-gradient(135deg, ${colors.primary}, ${colors.secondary})`,
-          border:
+          border: "none",
+        }}
+        animate={{
+          boxShadow:
             point.id === "mundo-gelado" ||
             point.id === "planeta-limite" ||
             point.id === "estacao-borda" ||
@@ -238,12 +241,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
             point.id === "estacao-omega" ||
             point.id === "terra-nova"
               ? "none"
-              : `1px solid ${colors.primary}40`,
-        }}
-        animate={{
-          boxShadow: isNearby
-            ? `0 0 20px ${colors.glow}`
-            : `0 0 8px ${colors.glow}60`,
+              : isNearby
+                ? `0 0 20px ${colors.glow}`
+                : `0 0 8px ${colors.glow}60`,
         }}
       >
         {point.id === "mundo-gelado" ? (

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -333,7 +333,8 @@ export const MapPoint: React.FC<MapPointProps> = ({
       {/* Orbit rings for planets - skip for custom images */}
       {point.type === "planet" &&
         point.id !== "mundo-gelado" &&
-        point.id !== "planeta-limite" && (
+        point.id !== "planeta-limite" &&
+        point.id !== "terra-nova" && (
           <motion.div
             className="absolute inset-0 rounded-full border border-white/20 -z-10"
             style={{

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -248,43 +248,43 @@ export const MapPoint: React.FC<MapPointProps> = ({
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F7e4bf7fbfae64dec9a1f6cc4cf45cae2?format=webp&width=800"
             alt="Mundo Gelado"
-            className="w-45 h-45 object-contain"
+            className="w-32 h-32 object-cover"
           />
         ) : point.id === "planeta-limite" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F32e8fdb02b8847e2905c284b102c06f1?format=webp&width=800"
             alt="Planeta Limite"
-            className="w-45 h-45 object-contain"
+            className="w-32 h-32 object-cover"
           />
         ) : point.id === "estacao-borda" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fddc08062fa4847258d35e5b4220283d2?format=webp&width=800"
             alt="Estação da Borda"
-            className="w-45 h-45 object-contain"
+            className="w-32 h-32 object-cover"
           />
         ) : point.id === "campo-asteroides" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fd72456f351f44914a7041ea650599fa5?format=webp&width=800"
             alt="Campo de Asteroides"
-            className="w-45 h-45 object-contain"
+            className="w-32 h-32 object-cover"
           />
         ) : point.id === "nebulosa-crimson" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F69aee9aae2844db097785996005e39f4?format=webp&width=800"
             alt="Nebulosa Crimson"
-            className="w-45 h-45 object-contain"
+            className="w-32 h-32 object-cover"
           />
         ) : point.id === "estacao-omega" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F33bc3a2c9ab640e8a3a4e31a127b186c?format=webp&width=800"
             alt="Estação Omega"
-            className="w-45 h-45 object-contain"
+            className="w-32 h-32 object-cover"
           />
         ) : point.id === "terra-nova" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F50c9b6d67a104a3493aa90dd1b8ec545?format=webp&width=800"
             alt="Terra Nova"
-            className="w-45 h-45 object-contain"
+            className="w-32 h-32 object-cover"
           />
         ) : (
           <Icon size={14} className="text-white drop-shadow-sm" />

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -248,43 +248,43 @@ export const MapPoint: React.FC<MapPointProps> = ({
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F7e4bf7fbfae64dec9a1f6cc4cf45cae2?format=webp&width=800"
             alt="Mundo Gelado"
-            className="w-60 h-60 object-contain"
+            className="w-45 h-45 object-contain"
           />
         ) : point.id === "planeta-limite" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F32e8fdb02b8847e2905c284b102c06f1?format=webp&width=800"
             alt="Planeta Limite"
-            className="w-60 h-60 object-contain"
+            className="w-45 h-45 object-contain"
           />
         ) : point.id === "estacao-borda" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fddc08062fa4847258d35e5b4220283d2?format=webp&width=800"
             alt="Estação da Borda"
-            className="w-60 h-60 object-contain"
+            className="w-45 h-45 object-contain"
           />
         ) : point.id === "campo-asteroides" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fd72456f351f44914a7041ea650599fa5?format=webp&width=800"
             alt="Campo de Asteroides"
-            className="w-60 h-60 object-contain"
+            className="w-45 h-45 object-contain"
           />
         ) : point.id === "nebulosa-crimson" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F69aee9aae2844db097785996005e39f4?format=webp&width=800"
             alt="Nebulosa Crimson"
-            className="w-60 h-60 object-contain"
+            className="w-45 h-45 object-contain"
           />
         ) : point.id === "estacao-omega" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F33bc3a2c9ab640e8a3a4e31a127b186c?format=webp&width=800"
             alt="Estação Omega"
-            className="w-60 h-60 object-contain"
+            className="w-45 h-45 object-contain"
           />
         ) : point.id === "terra-nova" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F50c9b6d67a104a3493aa90dd1b8ec545?format=webp&width=800"
             alt="Terra Nova"
-            className="w-60 h-60 object-contain"
+            className="w-45 h-45 object-contain"
           />
         ) : (
           <Icon size={14} className="text-white drop-shadow-sm" />

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -245,46 +245,123 @@ export const MapPoint: React.FC<MapPointProps> = ({
         }}
       >
         {point.id === "mundo-gelado" ? (
-          <img
+          <motion.img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F7e4bf7fbfae64dec9a1f6cc4cf45cae2?format=webp&width=800"
             alt="Mundo Gelado"
             className="w-32 h-32 object-cover"
+            animate={{
+              y: [0, -8, 0],
+              x: [0, 3, 0],
+              rotate: [0, 1, 0, -1, 0],
+            }}
+            transition={{
+              duration: 6,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: 0,
+            }}
           />
         ) : point.id === "planeta-limite" ? (
-          <img
+          <motion.img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F32e8fdb02b8847e2905c284b102c06f1?format=webp&width=800"
             alt="Planeta Limite"
             className="w-32 h-32 object-cover"
+            animate={{
+              y: [0, -5, 0],
+              x: [0, -4, 0],
+              rotate: [0, -0.8, 0, 0.8, 0],
+            }}
+            transition={{
+              duration: 7.5,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: 1.2,
+            }}
           />
         ) : point.id === "estacao-borda" ? (
-          <img
+          <motion.img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fddc08062fa4847258d35e5b4220283d2?format=webp&width=800"
             alt="Estação da Borda"
             className="w-32 h-32 object-cover"
+            animate={{
+              y: [0, -6, 0],
+              x: [0, 2, 0],
+              rotate: [0, 1.2, 0, -0.6, 0],
+            }}
+            transition={{
+              duration: 5.8,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: 2.1,
+            }}
           />
         ) : point.id === "campo-asteroides" ? (
-          <img
+          <motion.img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fd72456f351f44914a7041ea650599fa5?format=webp&width=800"
             alt="Campo de Asteroides"
             className="w-32 h-32 object-cover"
+            animate={{
+              y: [0, -7, 0],
+              x: [0, -3, 0],
+              rotate: [0, -1.5, 0, 1, 0],
+            }}
+            transition={{
+              duration: 6.7,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: 0.8,
+            }}
           />
         ) : point.id === "nebulosa-crimson" ? (
-          <img
+          <motion.img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F69aee9aae2844db097785996005e39f4?format=webp&width=800"
             alt="Nebulosa Crimson"
             className="w-32 h-32 object-cover"
+            animate={{
+              y: [0, -9, 0],
+              x: [0, 4, 0],
+              rotate: [0, 0.9, 0, -1.2, 0],
+            }}
+            transition={{
+              duration: 8.2,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: 1.8,
+            }}
           />
         ) : point.id === "estacao-omega" ? (
-          <img
+          <motion.img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F33bc3a2c9ab640e8a3a4e31a127b186c?format=webp&width=800"
             alt="Estação Omega"
             className="w-32 h-32 object-cover"
+            animate={{
+              y: [0, -4, 0],
+              x: [0, -2, 0],
+              rotate: [0, -0.7, 0, 0.9, 0],
+            }}
+            transition={{
+              duration: 5.5,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: 2.7,
+            }}
           />
         ) : point.id === "terra-nova" ? (
-          <img
+          <motion.img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F50c9b6d67a104a3493aa90dd1b8ec545?format=webp&width=800"
             alt="Terra Nova"
             className="w-32 h-32 object-cover"
+            animate={{
+              y: [0, -6, 0],
+              x: [0, 3, 0],
+              rotate: [0, 1.1, 0, -0.8, 0],
+            }}
+            transition={{
+              duration: 7,
+              repeat: Infinity,
+              ease: "easeInOut",
+              delay: 1.5,
+            }}
           />
         ) : (
           <Icon size={14} className="text-white drop-shadow-sm" />

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -196,7 +196,7 @@ export const MapPoint: React.FC<MapPointProps> = ({
 
       {/* Main point */}
       <motion.div
-        className={`relative flex items-center justify-center shadow-lg backdrop-blur-sm overflow-hidden ${
+        className={
           point.id === "mundo-gelado" ||
           point.id === "planeta-limite" ||
           point.id === "estacao-borda" ||
@@ -204,9 +204,9 @@ export const MapPoint: React.FC<MapPointProps> = ({
           point.id === "nebulosa-crimson" ||
           point.id === "estacao-omega" ||
           point.id === "terra-nova"
-            ? "w-60 h-60 rounded-full"
-            : "w-6 h-6 rounded-full"
-        }`}
+            ? "relative"
+            : "relative flex items-center justify-center w-6 h-6 rounded-full shadow-lg backdrop-blur-sm overflow-hidden"
+        }
         style={{
           background:
             point.id === "mundo-gelado" ||
@@ -218,7 +218,16 @@ export const MapPoint: React.FC<MapPointProps> = ({
             point.id === "terra-nova"
               ? "transparent"
               : `linear-gradient(135deg, ${colors.primary}, ${colors.secondary})`,
-          border: "none",
+          border:
+            point.id === "mundo-gelado" ||
+            point.id === "planeta-limite" ||
+            point.id === "estacao-borda" ||
+            point.id === "campo-asteroides" ||
+            point.id === "nebulosa-crimson" ||
+            point.id === "estacao-omega" ||
+            point.id === "terra-nova"
+              ? "none"
+              : `1px solid ${colors.primary}40`,
         }}
         animate={{
           boxShadow:

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -161,18 +161,7 @@ export const MapPoint: React.FC<MapPointProps> = ({
       animate={{
         opacity: 1,
         scale: 1,
-        filter:
-          point.id === "mundo-gelado" ||
-          point.id === "planeta-limite" ||
-          point.id === "estacao-borda" ||
-          point.id === "campo-asteroides" ||
-          point.id === "nebulosa-crimson" ||
-          point.id === "estacao-omega" ||
-          point.id === "terra-nova"
-            ? "none"
-            : isNearby
-              ? `drop-shadow(0 0 12px ${colors.glow})`
-              : `drop-shadow(0 0 6px ${colors.glow})`,
+        filter: "none",
       }}
       transition={{
         type: "spring",

--- a/src/components/World/MapPoint.tsx
+++ b/src/components/World/MapPoint.tsx
@@ -239,43 +239,43 @@ export const MapPoint: React.FC<MapPointProps> = ({
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F7e4bf7fbfae64dec9a1f6cc4cf45cae2?format=webp&width=800"
             alt="Mundo Gelado"
-            className="w-full h-full object-cover"
+            className="w-full h-full object-cover rounded-full"
           />
         ) : point.id === "planeta-limite" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F32e8fdb02b8847e2905c284b102c06f1?format=webp&width=800"
             alt="Planeta Limite"
-            className="w-full h-full object-contain"
+            className="w-full h-full object-cover rounded-full"
           />
         ) : point.id === "estacao-borda" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fddc08062fa4847258d35e5b4220283d2?format=webp&width=800"
             alt="Estação da Borda"
-            className="w-full h-full object-contain"
+            className="w-full h-full object-cover rounded-full"
           />
         ) : point.id === "campo-asteroides" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2Fd72456f351f44914a7041ea650599fa5?format=webp&width=800"
             alt="Campo de Asteroides"
-            className="w-full h-full object-contain"
+            className="w-full h-full object-cover rounded-full"
           />
         ) : point.id === "nebulosa-crimson" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F69aee9aae2844db097785996005e39f4?format=webp&width=800"
             alt="Nebulosa Crimson"
-            className="w-full h-full object-contain"
+            className="w-full h-full object-cover rounded-full"
           />
         ) : point.id === "estacao-omega" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F33bc3a2c9ab640e8a3a4e31a127b186c?format=webp&width=800"
             alt="Estação Omega"
-            className="w-full h-full object-contain"
+            className="w-full h-full object-cover rounded-full"
           />
         ) : point.id === "terra-nova" ? (
           <img
             src="https://cdn.builder.io/api/v1/image/assets%2Fab1d9d92bc174226b835128749a95e68%2F50c9b6d67a104a3493aa90dd1b8ec545?format=webp&width=800"
             alt="Terra Nova"
-            className="w-full h-full object-contain"
+            className="w-full h-full object-cover rounded-full"
           />
         ) : (
           <Icon size={14} className="text-white drop-shadow-sm" />


### PR DESCRIPTION
This commit refactors the MapPoint component with the following changes:

- Remove conditional filter logic and set filter to "none" for all points
- Restructure className logic for better readability and maintainability
- Add conditional boxShadow animations based on point ID
- Convert static img elements to motion.img with floating animations
- Update image sizing from full container to fixed 32x32 dimensions
- Add unique animation properties (y, x, rotate) for each planet with different durations and delays
- Add drop-shadow filter styling to all planet images
- Exclude "terra-nova" from orbit ring rendering logic

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/67f60fba26754401b7422c9966f56e7d/spark-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>67f60fba26754401b7422c9966f56e7d</projectId>-->
<!--<branchName>spark-field</branchName>-->